### PR TITLE
Check if typeof link is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1]
+
+### Fixed
+
+- Check if typeof link is undefined (#3)
+
 ## [1.0.0]
 
 First release
 
 [1.0.0]: https://github.com/photogabble/eleventy-plugin-font-subsetting/releases/tag/v1.0.0
+[1.0.1]: https://github.com/photogabble/eleventy-plugin-font-subsetting/releases/tag/v1.0.1

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ module.exports = function (eleventyConfig, options = {}) {
 
               return aliases.has(link.slug);
             }))
-            .filter(link => (typeof link !== undefined))
+            .filter(link => (typeof link !== 'undefined'))
             .forEach(link => compilePromises.push(compileTemplate(link)))
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photogabble/eleventy-plugin-interlinker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Obsidian WikiLinks, BackLinks and Embed support for 11ty",
   "keywords": [
     "11ty",


### PR DESCRIPTION
Fixes a silly mistake where I was checking if type of was `undefined` rather than `'undefined'`; this meant if the plugin couldn't find a inbound link it would crash your build.