### PR TITLE
Release 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5]
+
+- Change to use `url` instead of `inputPath` for unique page key, this is because some pages can share the same `inputPath` such as those generated via pagination.
+
 ## [1.0.4]
 
 - Bugfix template `content` variable not being set when rendering embed (#10)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ Using the vertical bar (`|`) you can change the text used to display a link. Thi
 
 Aliases provide you a way of referencing a file using different names, use the `aliases` property in your font matter to list one or more aliases that can be used to reference the file from a Wiki Link. For example, you might add _AI_ as an alias of a file titled _Artificial Intelligence_ which would then be linkable via `[[AI]]`.
 
+### Linking to Pagination generated pages
+
+A common use of pagination in 11ty is [pagination of an object](https://www.11ty.dev/docs/pagination/#paging-an-object) or data file, by default these generated pages aren't included in the all pages collection and therefore are invisible to this plugin unless you set `addAllPagesToCollections: true`.
+
+Once done you will also need to set the title of each generated page so that this plugin can reference them, that can be done with `eleventyComputed` for example:
+
+```yaml
+---
+pagination:
+  data: collections.lists
+  size: 1
+  alias: list
+  addAllPagesToCollections: true
+permalink: "{{ list.permalink }}"
+folder: lists
+eleventyComputed:
+  title: "{{ list.title }}"
+---
+```
+
 ### Embedding
 
 Embedding files allows you to reuse content across your website while tracking what pages have used it.

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (eleventyConfig, options = {}) {
   const wikilinkParser = new WikilinkParser(opts);
 
   const compileTemplate = async (data) => {
-    if (compiledEmbeds.has(data.inputPath)) return;
+    if (compiledEmbeds.has(data.url)) return;
 
     const frontMatter = data.template.frontMatter;
 
@@ -51,7 +51,7 @@ module.exports = function (eleventyConfig, options = {}) {
     const fn = await rm.compile(tpl, language, {templateConfig, extensionMap});
     const result = await fn({content: frontMatter.content, ...data.data});
 
-    compiledEmbeds.set(data.inputPath, result);
+    compiledEmbeds.set(data.url, result);
   }
 
   let templateConfig;
@@ -107,14 +107,14 @@ module.exports = function (eleventyConfig, options = {}) {
       const currentSlug = opts.slugifyFn(data.title);
       let backlinks = [];
       let currentSlugs = new Set([currentSlug, data.page.fileSlug]);
-      const currentPage = allPages.find(page => page.inputPath === data.page.inputPath);
+      const currentPage = allPages.find(page => page.url === data.page.url);
 
       // Populate our link map for use later in replacing WikiLinks with page permalinks.
       // Pages can list aliases in their front matter, if those exist we should map them
       // as well.
 
       linkMapCache.set(currentSlug, {
-        page: data.collections.all.find(page => page.inputPath === data.page.inputPath),
+        page: data.collections.all.find(page => page.url === data.page.url),
         title: data.title
       });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@photogabble/eleventy-plugin-interlinker",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Obsidian WikiLinks, BackLinks and Embed support for 11ty",
   "keywords": [
     "11ty",

--- a/src/markdown-ext.js
+++ b/src/markdown-ext.js
@@ -64,10 +64,10 @@ const wikilinkRenderRule = (wikilinkParser, linkMapCache, compiledEmbeds, deadWi
         : '';
     }
 
-    const templateContent = compiledEmbeds.get(link.page.inputPath);
+    const templateContent = compiledEmbeds.get(link.page.url);
     if (!templateContent) throw new Error(`WikiLink Embed found pointing to [${token.content}], has no compiled template.`);
 
-    return compiledEmbeds.get(link.page.inputPath);
+    return compiledEmbeds.get(link.page.url);
   }
 
   const anchor = {

--- a/tests/fixtures/multiline.html
+++ b/tests/fixtures/multiline.html
@@ -1,12 +1,12 @@
-<p>This is a multiline file with <a href="/wiki-link">Wikilinks</a> and embeds to test that the inline rule works as expected.</p>
+<p>This is a multiline file with <a href="/wiki-link/">Wikilinks</a> and embeds to test that the inline rule works as expected.</p>
 <p><div>Embed on its own</div></p>
 <p>This paragraph includes an <span>inline embed</span> which could be used for embedding links and tracking their usage. Doing so is useful say you want to collect bookmarks and link those from multiple places and see usage.</p>
 <blockquote>
-<p>This <a href="/wiki-link">Wiki Link</a> is inside a quote block.</p>
+<p>This <a href="/wiki-link/">Wiki Link</a> is inside a quote block.</p>
 </blockquote>
 <ul>
 <li>Other</li>
 <li>usage</li>
 <li>might be</li>
-<li>including a <a href="/wiki-link">Wiki Link</a> inside a list</li>
+<li>including a <a href="/wiki-link/">Wiki Link</a> inside a list</li>
 </ul>

--- a/tests/markdown-wikilink-renderer.test.js
+++ b/tests/markdown-wikilink-renderer.test.js
@@ -15,7 +15,7 @@ test('inline rule correctly parses single wikilink', t => {
   linkMapCache.set('wiki-link', {
     title: 'Wiki Link',
     page: {
-      url: '/wiki-link'
+      url: '/wiki-link/'
     }
   });
 
@@ -33,7 +33,7 @@ test('inline rule correctly parses single wikilink', t => {
   );
 
   t.is(
-    "<p>Hello world, this is some text with a <a href=\"/wiki-link\">Wiki Link</a> inside!</p>\n",
+    "<p>Hello world, this is some text with a <a href=\"/wiki-link/\">Wiki Link</a> inside!</p>\n",
     md.render('Hello world, this is some text with a [[wiki link]] inside!', {})
   );
 });
@@ -46,14 +46,14 @@ test('inline rule correctly parses multiple wikilinks', t => {
   linkMapCache.set('wiki-link', {
     title: 'Wiki Link',
     page: {
-      url: '/wiki-link'
+      url: '/wiki-link/'
     }
   });
 
   linkMapCache.set('another-wiki-link', {
     title: 'Another Wiki Link',
     page: {
-      url: '/another-wiki-link'
+      url: '/another-wiki-link/'
     }
   });
 
@@ -71,7 +71,7 @@ test('inline rule correctly parses multiple wikilinks', t => {
   );
 
   t.is(
-    "<p>Hello world, this is some text with a <a href=\"/wiki-link\">Wiki Link</a> inside! There is also <a href=\"/another-wiki-link\">Another Wiki Link</a> in the same string.</p>\n",
+    "<p>Hello world, this is some text with a <a href=\"/wiki-link/\">Wiki Link</a> inside! There is also <a href=\"/another-wiki-link/\">Another Wiki Link</a> in the same string.</p>\n",
     md.render('Hello world, this is some text with a [[wiki link]] inside! There is also [[another wiki link]] in the same string.', {})
   );
 });
@@ -85,11 +85,11 @@ test('inline rule correctly parses single embed', t => {
     title: 'Wiki Embed',
     page: {
       inputPath: '/src/wiki-embed.md',
-      url: '/wiki-embed'
+      url: '/wiki-embed/'
     }
   });
 
-  compiledEmbeds.set('/src/wiki-embed.md', '<span>Wiki Embed Test</span>');
+  compiledEmbeds.set('/wiki-embed/', '<span>Wiki Embed Test</span>');
 
   const md = require('markdown-it')({html: true});
   md.inline.ruler.push('inline_wikilink', wikilinkInlineRule(
@@ -119,7 +119,7 @@ test('inline rule correctly parses mixed wikilink and embed in multiline input',
     title: 'Inline Embed',
     page: {
       inputPath: '/src/inline-embed.md',
-      url: '/inline-embed'
+      url: '/inline-embed/'
     }
   });
 
@@ -127,7 +127,7 @@ test('inline rule correctly parses mixed wikilink and embed in multiline input',
     title: 'This is an embed on its own',
     page: {
       inputPath: '/src/lonely-embed.md',
-      url: '/lonely-embed'
+      url: '/lonely-embed/'
     }
   });
 
@@ -135,12 +135,12 @@ test('inline rule correctly parses mixed wikilink and embed in multiline input',
     title: 'Wiki Link',
     page: {
       inputPath: '/src/wiki-link.md',
-      url: '/wiki-link'
+      url: '/wiki-link/'
     }
   });
 
-  compiledEmbeds.set('/src/inline-embed.md', '<span>inline embed</span>');
-  compiledEmbeds.set('/src/lonely-embed.md', '<div>Embed on its own</div>');
+  compiledEmbeds.set('/inline-embed/', '<span>inline embed</span>');
+  compiledEmbeds.set('/lonely-embed/', '<div>Embed on its own</div>');
 
   const md = require('markdown-it')({html: true});
   md.inline.ruler.push('inline_wikilink', wikilinkInlineRule(


### PR DESCRIPTION
This release changes how the plugin identifies unique pages and in doing so makes it possible for it to be aware of pages generated via pagination. This release paves the way for #13 and additionally being able to parse regular `<a>` tags for internal links!