### PR TITLE
REFACTOR: Improve performance and add support for HTML Links

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,9 @@ module.exports = function (eleventyConfig, options = {}) {
     );
   });
 
-  // Add backlinks computed global data, this is executed before the templates are compiled and thus markdown parsed.
+  // Add outboundLinks computed global data, this is executed before the templates are compiled and
+  // thus markdown parsed.
   eleventyConfig.addGlobalData('eleventyComputed', {
-    backlinks: async (data) => await interlinker.computeBacklinks(data)
+    outboundLinks: async (data) => await interlinker.compute(data)
   });
 };

--- a/src/html-link-parser.js
+++ b/src/html-link-parser.js
@@ -1,0 +1,42 @@
+module.exports = class HTMLLinkParser {
+
+  /**
+   * This regex finds all html tags with an href that begins with / denoting they are internal links.
+   *
+   * @type {RegExp}
+   */
+  internalLinkRegex = /href="\/(.*?)"/g;
+
+  /**
+   * Parses a single HTML link into the link object understood by the Interlinker. Unlike with Wikilinks we only
+   * care about the href so that we can look up the linked page record.
+   *
+   * @param {string} link
+   * @return {{isEmbed: boolean, href: string}}
+   */
+  parseSingle(link) {
+    return {
+      href: link.slice(6, -1)
+        .replace(/.(md|markdown)\s?$/i, "")
+        .replace("\\", "")
+        .trim()
+        .split("#")[0],
+      isEmbed: false,
+    }
+  }
+
+  parseMultiple(links) {
+    return links.map(link => this.parseSingle(link));
+  }
+
+  /**
+   * Find's all internal href links within an HTML document.
+   * @param {string} document
+   * @return {Array<{isEmbed: false, href: string}>}
+   */
+  find(document) {
+    return this.parseMultiple(
+      (document.match(this.internalLinkRegex) || [])
+    )
+  }
+}

--- a/src/wikilink-parser.js
+++ b/src/wikilink-parser.js
@@ -1,6 +1,7 @@
 module.exports = class WikilinkParser {
   /**
    * This regex finds all WikiLink style links: [[id|optional text]] as well as WikiLink style embeds: ![[id]]
+   *
    * @type {RegExp}
    */
   wikiLinkRegExp = /(?<!!)(!?)\[\[([^|]+?)(\|([\s\S]+?))?]]/g;
@@ -12,6 +13,15 @@ module.exports = class WikilinkParser {
     this.slugifyFn = opts.slugifyFn;
   }
 
+  /**
+   * Parses a single WikiLink into the link object understood by the Interlinker.
+   *
+   * @todo add parsing of namespace (#14)
+   * @todo add support for referencing file by path (#13)
+   *
+   * @param {string} link
+   * @return {{isEmbed: boolean, anchor: (string|null), name: string, link: string, title: (string|null), slug: string}}
+   */
   parseSingle(link) {
     const isEmbed = link.startsWith('!');
     const parts = link.slice((isEmbed ? 3 : 2), -2).split("|").map(part => part.trim());
@@ -37,5 +47,16 @@ module.exports = class WikilinkParser {
 
   parseMultiple(links) {
     return links.map(link => this.parseSingle(link));
+  }
+
+  /**
+   * Finds all wikilinks within a document (HTML or otherwise).
+   * @param {string} document
+   * @return {{isEmbed: boolean, anchor: (string|null), name: string, link: string, title: (string|null), slug: string}}
+   */
+  find(document) {
+    return this.parseMultiple(
+      (document.match(this.wikiLinkRegExp) || [])
+    )
   }
 }

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -1,22 +1,28 @@
 const test = require("ava");
 const Eleventy = require("@11ty/eleventy");
-const{normalize} = require('./helpers');
+const {normalize} = require('./helpers');
 
-test("Sample page (wikilink from markdown to liquid)", async t => {
+function findResultByUrl(results, url) {
+  const [result] = results.filter(result => result.url === url);
+  return result;
+}
+
+test("Sample page (wikilinks and regular links)", async t => {
   let elev = new Eleventy(`${__dirname}/fixtures/sample-small-website/`, `${__dirname}/fixtures/sample-small-website/_site`, {
-    configPath: `${__dirname}/fixtures/sample-small-website/eleventy.config.js`
+    configPath: `${__dirname}/fixtures/sample-small-website/eleventy.config.js`,
   });
 
   let results = await elev.toJSON();
 
   t.is(2, results.length);
 
-  const [result] = results.filter(result => result.url === '/about/');
+  t.is(
+    `<div><p>This is to show that we can link between Markdown files and <a href="/hello/">liquid files</a>.</p></div><div><a href="/hello/">Hello</a></div>`,
+    normalize(findResultByUrl(results, '/about/').content)
+  );
 
   t.is(
-    '<p>This is to show that we can link between Markdown files and <a href="/hello/">liquid files</a>.</p>',
-    normalize(result.content)
+    '<div>This is to show that we can link back via <a href="/about">regular <em>internal</em> links</a>.</div><div><a href="/about/">About</a></div>',
+    normalize(findResultByUrl(results, '/hello/').content)
   );
 });
-
-

--- a/tests/fixtures/sample-small-website/_layouts/default.liquid
+++ b/tests/fixtures/sample-small-website/_layouts/default.liquid
@@ -1,0 +1,2 @@
+<div>{{ content }}</div>
+<div>{%- for link in backlinks %}<a href="{{ link.url }}">{{ link.title }}</a>{%- endfor %}</div>

--- a/tests/fixtures/sample-small-website/about.md
+++ b/tests/fixtures/sample-small-website/about.md
@@ -1,5 +1,6 @@
 ---
 title: About
+layout: default.liquid
 ---
 
 This is to show that we can link between Markdown files and [[hello|liquid files]].

--- a/tests/fixtures/sample-small-website/hello.liquid
+++ b/tests/fixtures/sample-small-website/hello.liquid
@@ -1,5 +1,6 @@
 ---
 title: Hello
+layout: default.liquid
 ---
 
-Hello World!
+This is to show that we can link back via <a href="/about">regular <em>internal</em> links</a>.

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,5 +1,5 @@
 function normalize(str) {
-  return str.trim().replace(/\r\n/g, "\n");
+  return str.trim().replace(/\r?\n|\r/g, '');
 }
 
 module.exports = {

--- a/tests/html-internal-link-parser.test.js
+++ b/tests/html-internal-link-parser.test.js
@@ -1,0 +1,21 @@
+const HTMLLinkParser = require('../src/html-link-parser');
+const test = require('ava');
+
+test('html link parser grabs multiple href, ignoring external links', t => {
+    const parser = new HTMLLinkParser();
+    const links = parser.find('<p>Hello world <a href="/home">this is a link home</a> and <a href="/somewhere">this is a link somewhere</a></p><p>The following link should be ignored <a href="http://www.example.com/">example.com</a>.</p>');
+
+    t.is(2, links.length);
+
+    const expectedLinks = ['/home', '/somewhere'];
+    for (const link of links) {
+      t.is(false, link.isEmbed); // HTML embed not supported for anchor links
+
+      const idx = expectedLinks.indexOf(link.href);
+      t.is(true, idx !== -1);
+
+      expectedLinks.splice(idx, 1);
+    }
+
+    t.is(0, expectedLinks.length);
+});


### PR DESCRIPTION
This PR does two things:

- refactored the global computed value so that it computes each files outbound links and while doing so populates the backlinks array of pages found linking to. This reduces an expensive loop over all pages for each page the backlinks was being computed for
- added HTML link parser and test fixture running 11ty programatically so see the added functionality working in situ