### PR TITLE
BUGFIX: pass page object through to compileTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bugfix pass 11ty page object to embed compiler function
 - Add inclusion of html internal links to backlink computation (#22)
 - Add detailed bad link report (#26)
 
@@ -49,3 +50,4 @@ First release
 [1.0.4]: https://github.com/photogabble/eleventy-plugin-font-subsetting/releases/tag/v1.0.4
 [1.0.5]: https://github.com/photogabble/eleventy-plugin-font-subsetting/releases/tag/v1.0.5
 [1.0.5]: https://github.com/photogabble/eleventy-plugin-font-subsetting/releases/tag/v1.0.6
+[Unreleased]: https://github.com/photogabble/eleventy-plugin-interlinker/tree/v1.1.0

--- a/index.js
+++ b/index.js
@@ -62,8 +62,8 @@ module.exports = function (eleventyConfig, options = {}) {
 
   // Add outboundLinks computed global data, this is executed before the templates are compiled and
   // thus markdown parsed.
-  eleventyConfig.addGlobalData('eleventyComputed', {
-    outboundLinks: async (data) => await interlinker.compute(data)
+  eleventyConfig.addGlobalData('eleventyComputed.outboundLinks', () => {
+    return async (data) => interlinker.compute(data);
   });
 
   // TODO: 1.1.0 Make Interlinker class available via global data

--- a/src/find-page.js
+++ b/src/find-page.js
@@ -17,6 +17,8 @@ const pageLookup = (allPages = [], slugifyFn) => {
         return true;
       }
 
+      // TODO: need a way to identify that wikilink is pointing to an alias, because the alias then becomes the link title
+
       const aliases = ((page.data.aliases && Array.isArray(page.data.aliases)) ? page.data.aliases : []).reduce(function (set, alias) {
         set.add(slugifyFn(alias));
         return set;

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -149,7 +149,7 @@ module.exports = class Interlinker {
         // If this is an embed and the embed template hasn't been compiled, add this to the queue
         // @TODO compiledEmbeds should be keyed by the wikilink text as i'll be allowing setting embed values via namespace, or other method e.g ![[ident||template]]
         if (link.isEmbed && this.compiledEmbeds.has(link.slug) === false) {
-          compilePromises.push(this.compileTemplate(link));
+          compilePromises.push(this.compileTemplate(page));
         }
 
         return link;

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -92,6 +92,9 @@ module.exports = class Interlinker {
       data.collections.all,
       slugifyFn
     );
+
+    // TODO: 1.1.0 remove currentSlug as part of (#13)
+
     const currentSlug = slugifyFn(data.title);
     let currentSlugs = new Set([currentSlug, data.page.fileSlug]);
     const currentPage = pageDirectory.findByFile(data);

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -84,7 +84,7 @@ module.exports = class Interlinker {
     // once they are met.
     // @see https://www.11ty.dev/docs/data-computed/#declaring-your-dependencies
     const dependencies = [data.title, data.page, data.collections.all];
-    if (dependencies[0] === undefined || !dependencies[1].fileSlug || dependencies[2].length === 0) return [];
+    if (dependencies[0] === undefined || !dependencies[1].inputPath || dependencies[2].length === 0) return [];
 
     const {slugifyFn} = this.opts;
 

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -3,7 +3,6 @@ const WikilinkParser = require("./wikilink-parser");
 const {EleventyRenderPlugin} = require("@11ty/eleventy");
 const DeadLinks = require("./dead-links");
 const {pageLookup} = require("./find-page");
-const chalk = require("chalk");
 
 /**
  * Interlinker:

--- a/src/wikilink-parser.js
+++ b/src/wikilink-parser.js
@@ -19,10 +19,6 @@ module.exports = class WikilinkParser {
     this.linkCache = new Map();
   }
 
-  setPage(page) {
-    this.page = page;
-  }
-
   /**
    * Parses a single WikiLink into the link object understood by the Interlinker.
    *

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -65,3 +65,23 @@ test("Broken page (wikilinks and regular links)", async t => {
 
   t.is(logLines.length, 4, 'console.warn should be called three times');
 });
+
+test("Sample page (with embed)", async t => {
+  let elev = new Eleventy(fixturePath('sample-with-simple-embed'), fixturePath('sample-with-simple-embed/_site'), {
+    configPath: fixturePath('sample-with-simple-embed/eleventy.config.js'),
+  });
+
+  let results = await elev.toJSON();
+
+  // Embedded page is aware of its embedding
+  t.is(
+    normalize(findResultByUrl(results, '/about/').content),
+    `<div><p>Hello world.</p></div><div><a href="/">Homepage</a></div>`
+  );
+
+  // Embed shows
+  t.is(
+    normalize(findResultByUrl(results, '/').content),
+    `<div><p><p>Hello world.</p></p></div><div></div>`
+  );
+});

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -66,7 +66,7 @@ test("Broken page (wikilinks and regular links)", async t => {
   t.is(logLines.length, 4, 'console.warn should be called three times');
 });
 
-test("Sample page (with embed)", async t => {
+test("Sample page (markdown with embed)", async t => {
   let elev = new Eleventy(fixturePath('sample-with-simple-embed'), fixturePath('sample-with-simple-embed/_site'), {
     configPath: fixturePath('sample-with-simple-embed/eleventy.config.js'),
   });
@@ -76,7 +76,7 @@ test("Sample page (with embed)", async t => {
   // Embedded page is aware of its embedding
   t.is(
     normalize(findResultByUrl(results, '/about/').content),
-    `<div><p>Hello world.</p></div><div><a href="/">Homepage</a></div>`
+    `<div><p>Hello world.</p></div><div><a href="/">Something</a></div>`
   );
 
   // Embed shows

--- a/tests/fixtures/sample-with-simple-embed/_layouts/default.liquid
+++ b/tests/fixtures/sample-with-simple-embed/_layouts/default.liquid
@@ -1,0 +1,2 @@
+<div>{{ content }}</div>
+<div>{%- for link in backlinks %}<a href="{{ link.url }}">{{ link.title }}</a>{%- endfor %}</div>

--- a/tests/fixtures/sample-with-simple-embed/about.md
+++ b/tests/fixtures/sample-with-simple-embed/about.md
@@ -1,0 +1,6 @@
+---
+title: About
+layout: default.liquid
+---
+
+Hello world.

--- a/tests/fixtures/sample-with-simple-embed/eleventy.config.js
+++ b/tests/fixtures/sample-with-simple-embed/eleventy.config.js
@@ -1,0 +1,12 @@
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(
+    require('../../../index.js'),
+  );
+
+  return {
+    dir: {
+      includes: "_includes",
+      layouts: "_layouts",
+    }
+  }
+}

--- a/tests/fixtures/sample-with-simple-embed/index.md
+++ b/tests/fixtures/sample-with-simple-embed/index.md
@@ -1,0 +1,6 @@
+---
+title: Homepage
+layout: default.liquid
+---
+
+![[about]]

--- a/tests/fixtures/sample-with-simple-embed/index.md
+++ b/tests/fixtures/sample-with-simple-embed/index.md
@@ -1,5 +1,5 @@
 ---
-title: Homepage
+title: Something
 layout: default.liquid
 ---
 


### PR DESCRIPTION
This PR fixes a regression caused in an earlier refactoring as part of v1.1.0, where I was passing the wikilink meta object to `compileTemplate` instead of the 11ty page object.