### PR TITLE
BUGFIX: Pages Excluded from Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ module.exports = (eleventyConfig) => {
 
 ### Internal Links / Wikilinks
 
-This plugin will now parse all Wiki Links formatted for example, `[[Eleventy.js Interlink Plugin]]` appears as [Eleventy.js Interlink Plugin](https://photogabble.co.uk/projects/eleventyjs-interlink-plugin/).
+This plugin will parse both Wikilinks and internal anchor links. The Wikilink format is a **page reference** wrapped in double square brackets, for example: `[[Eleventy.js Interlink Plugin]]` will appear as [Eleventy.js Interlink Plugin](https://photogabble.co.uk/projects/eleventyjs-interlink-plugin/).
 
 Using the vertical bar (`|`) you can change the text used to display a link. This can be useful when you want to work a link into a sentence without using the title of the file, for example: `[[Eleventy.js Interlink Plugin|custom display text]]` appears as [custom display text](https://www.photogabble.co.uk/projects/eleventyjs-interlink-plugin/).
 
-> NOTE: By default this plugin will use the `title` front-matter attribute of your pages or one of the aliases (as detailed below).
+> **NOTE**: By default this plugin will use the `title` front-matter attribute of your pages or one of the aliases (as detailed below) as the **page reference**.
 
 ### Aliases
 
@@ -143,6 +143,10 @@ You can then display this information in any way you would like, I use the below
     </nav>
 {% endif %}
 ```
+
+### Pages Excluded from Collections
+
+Due to how this plugin obtains a pages template content, all pages with `eleventyExcludeFromCollections:true` set will **NOT** be parsed by the interlinker.
 
 ## Known Caveats
 

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -85,6 +85,8 @@ module.exports = class Interlinker {
     const dependencies = [data.title, data.page, data.collections.all];
     if (dependencies[0] === undefined || !dependencies[1].inputPath || dependencies[2].length === 0) return [];
 
+    this.deadLinks.setFileSrc(data.page.inputPath);
+
     const {slugifyFn} = this.opts;
 
     const compilePromises = [];
@@ -98,8 +100,7 @@ module.exports = class Interlinker {
     const currentSlug = slugifyFn(data.title);
     let currentSlugs = new Set([currentSlug, data.page.fileSlug]);
     const currentPage = pageDirectory.findByFile(data);
-
-    this.deadLinks.setFileSrc(currentPage.inputPath);
+    if (!currentPage) return [];
 
     // Populate our link map for use later in replacing WikiLinks with page permalinks.
     // Pages can list aliases in their front matter, if those exist we should map them

--- a/tests/fixtures/sample-with-excluded-file/_layouts/default.liquid
+++ b/tests/fixtures/sample-with-excluded-file/_layouts/default.liquid
@@ -1,0 +1,2 @@
+<div>{{ content }}</div>
+<div>{%- for link in backlinks %}<a href="{{ link.url }}">{{ link.title }}</a>{%- endfor %}</div>

--- a/tests/fixtures/sample-with-excluded-file/about.md
+++ b/tests/fixtures/sample-with-excluded-file/about.md
@@ -1,0 +1,6 @@
+---
+title: About
+layout: default.liquid
+---
+
+This wikilink to [[something]] will not parse because the destination has eleventyExcludeFromCollections set true.

--- a/tests/fixtures/sample-with-excluded-file/eleventy.config.js
+++ b/tests/fixtures/sample-with-excluded-file/eleventy.config.js
@@ -1,0 +1,12 @@
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(
+    require('../../../index.js'),
+  );
+
+  return {
+    dir: {
+      includes: "_includes",
+      layouts: "_layouts",
+    }
+  }
+}

--- a/tests/fixtures/sample-with-excluded-file/index.md
+++ b/tests/fixtures/sample-with-excluded-file/index.md
@@ -1,0 +1,7 @@
+---
+title: Something
+layout: default.liquid
+eleventyExcludeFromCollections: true
+---
+
+Hello World, no links, wiki or otherwise will be parsed by the interlinker due to being excluded from collections.

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,7 +1,30 @@
+const path = require("node:path");
+
 function normalize(str) {
   return str.trim().replace(/\r?\n|\r/g, '');
 }
 
+function consoleMockMessages(mock) {
+  let logLines = [];
+  for (let i = 0; i < mock.callCount; i++) {
+    const line = normalize(mock.getCall(i).args.join(' '))
+    // Sometimes 11ty will output benchmark info, failing the test randomly.
+    if (line.includes('[11ty]')) continue;
+    logLines.push(line);
+  }
+  return logLines;
+}
+
+function findResultByUrl(results, url) {
+  const [result] = results.filter(result => result.url === url);
+  return result;
+}
+
+const fixturePath = (p) => path.normalize(path.join(__dirname, 'fixtures', p));
+
 module.exports = {
   normalize,
+  consoleMockMessages,
+  findResultByUrl,
+  fixturePath,
 }


### PR DESCRIPTION
This PR fixes a bug raised in #28 caused by attempting to load an excluded page from the all collection.