### PR TITLE
BUGFIX: Don't render embeds if link doesn't exist

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ type WikilinkMeta = {
   link: string
   slug: string
   isEmbed: boolean
+  exists: boolean
 
   // href and path are loaded from the linked page
   href?: string

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -150,7 +150,7 @@ module.exports = class Interlinker {
 
         // If this is an embed and the embed template hasn't been compiled, add this to the queue
         // @TODO compiledEmbeds should be keyed by the wikilink text as i'll be allowing setting embed values via namespace, or other method e.g ![[ident||template]]
-        if (link.isEmbed && this.compiledEmbeds.has(link.slug) === false) {
+        if (link.isEmbed && link.exists && this.compiledEmbeds.has(link.slug) === false) {
           compilePromises.push(this.compileTemplate(page));
         }
 

--- a/src/wikilink-parser.js
+++ b/src/wikilink-parser.js
@@ -74,7 +74,8 @@ module.exports = class WikilinkParser {
       anchor,
       link,
       slug,
-      isEmbed
+      isEmbed,
+      exists: false,
     }
 
     // Lookup page data from 11ty's collection to obtain url and title if currently null
@@ -83,6 +84,7 @@ module.exports = class WikilinkParser {
       if (meta.title === null && page.data.title) meta.title = page.data.title;
       meta.href = page.url;
       meta.path = page.inputPath;
+      meta.exists = true;
     } else {
       // If this wikilink goes to a page that doesn't exist, add to deadLinks list and
       // update href for stub post.

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -123,3 +123,17 @@ test("Sample page (files with hash in title)", async t => {
     `<div><p>This link should be to <a href="/page/hello/#some-heading">a fragment identifier</a>.</p><p><p>Hello world.</p></p></div><div></div>`
   );
 });
+
+test("Sample with simple embed (broken embed)", async t => {
+  let elev = new Eleventy(fixturePath('sample-with-simple-embed'), fixturePath('sample-with-simple-embed/_site'), {
+    configPath: fixturePath('sample-with-simple-embed/eleventy.config.js'),
+  });
+
+  let results = await elev.toJSON();
+
+  // Bad Wikilink Embed shows default text
+  t.is(
+    normalize(findResultByUrl(results, '/broken/').content),
+    `<div><p>[UNABLE TO LOCATE EMBED]</p></div><div></div>`
+  );
+});

--- a/tests/fixtures/sample-with-simple-embed/broken-2.md
+++ b/tests/fixtures/sample-with-simple-embed/broken-2.md
@@ -1,0 +1,6 @@
+---
+title: Broken 2
+layout: default.liquid
+---
+
+![[this is broken]]

--- a/tests/fixtures/sample-with-simple-embed/broken.md
+++ b/tests/fixtures/sample-with-simple-embed/broken.md
@@ -1,0 +1,6 @@
+---
+title: Broken
+layout: default.liquid
+---
+
+![[this is broken]]

--- a/tests/fixtures/sample-with-simple-embed/stubs.md
+++ b/tests/fixtures/sample-with-simple-embed/stubs.md
@@ -1,0 +1,6 @@
+---
+title: Stubs
+layout: default.liquid
+---
+
+Stubby Stubs.


### PR DESCRIPTION
This PR solves an issue where the wikilink detection would set a links href to `/stubs/` before the interlinker looked up the file in question. This would result in the stubs page (if the file exists in the project) file object being loaded and passed to the embed compiler function.

On my website the stubs page is nunjucks and due to the plugin defaulting to liquid for rendering templates it would crash on invalid template syntax. This in of itself is a separate bug I will raise issue for.