### PR TITLE
BUGFIX: Broken dead-links lookup due to typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bugfix broken dead-links lookup due to typo (#38)
 - Bugfix do not render embeds if the page linked doesn't exist (#35)
 - Bugfix do not parse links in pages excluded from collections (#30)
 - Bugfix do not exclude root index page

--- a/src/dead-links.js
+++ b/src/dead-links.js
@@ -17,7 +17,7 @@ module.exports = class DeadLinks {
     if (!this.fileSrc) this.fileSrc = 'unknown';
 
     const names = this.gravestones.has(link)
-      ? this.gravestones.get(this.fileSrc)
+      ? this.gravestones.get(link)
       : [];
 
     names.push(this.fileSrc)


### PR DESCRIPTION
This PR fixes a bug that only shows when rebuilding a website while 11ty is run with the `--serve` flag.