### PR TITLE
BUGFIX: Use alias as link text if it's the lookup source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bugfix use alias as link text if it's the lookup source (#42)
 - Bugfix HTML encode link titles (#40)
 - Bugfix broken dead-links lookup due to typo (#38)
 - Bugfix do not render embeds if the page linked doesn't exist (#35)

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ type WikilinkMeta = {
 }
 
 interface PageDirectoryService {
-  findByLink(link : WikilinkMeta|LinkMeta): any;
+  findByLink(link : WikilinkMeta|LinkMeta): {page: any, found: boolean, foundByAlias: boolean};
   findByFile(file : any): any;
 }
 

--- a/src/find-page.js
+++ b/src/find-page.js
@@ -8,26 +8,36 @@
  */
 const pageLookup = (allPages = [], slugifyFn) => {
   return {
-    findByLink: (link) => allPages.find((page) => {
-      if (link.href && (page.url === link.href || page.url === `${link.href}/`)) {
-        return true;
+    findByLink: (link) => {
+      let foundByAlias = false;
+      const page = allPages.find((page) => {
+        if (link.href && (page.url === link.href || page.url === `${link.href}/`)) {
+          return true;
+        }
+
+        // TODO: is there a need to slug the page title for comparison? We can match on link.name === page.data.title!
+
+        if (page.fileSlug === link.slug || (page.data.title && slugifyFn(page.data.title) === link.slug)) {
+          return true;
+        }
+
+        // TODO: need a way to identify that wikilink is pointing to an alias, because the alias then becomes the link title
+
+        const aliases = ((page.data.aliases && Array.isArray(page.data.aliases)) ? page.data.aliases : []).reduce(function (set, alias) {
+          set.add(alias);
+          return set;
+        }, new Set());
+
+        foundByAlias = aliases.has(link.name);
+        return foundByAlias;
+      });
+
+      return {
+        found: !!page,
+        page,
+        foundByAlias,
       }
-
-      // TODO: is there a need to slug the page title for comparison? We can match on link.name === page.data.title!
-
-      if (page.fileSlug === link.slug || (page.data.title && slugifyFn(page.data.title) === link.slug)) {
-        return true;
-      }
-
-      // TODO: need a way to identify that wikilink is pointing to an alias, because the alias then becomes the link title
-
-      const aliases = ((page.data.aliases && Array.isArray(page.data.aliases)) ? page.data.aliases : []).reduce(function (set, alias) {
-        set.add(slugifyFn(alias));
-        return set;
-      }, new Set());
-
-      return aliases.has(link.slug);
-    }),
+    },
 
     findByFile: (file) => allPages.find((page) => page.url === file.page.url),
   }

--- a/src/html-link-parser.js
+++ b/src/html-link-parser.js
@@ -32,7 +32,7 @@ module.exports = class HTMLLinkParser {
       isEmbed: false,
     };
 
-    if (!pageDirectory.findByLink(meta)) {
+    if (!pageDirectory.findByLink(meta).found) {
       this.deadLinks.add(link);
     }
 

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -136,8 +136,8 @@ module.exports = class Interlinker {
         ...this.HTMLLinkParser.find(pageContent, pageDirectory),
       ].map((link) => {
         // Lookup the page this link, links to and add this page to its backlinks
-        const page = pageDirectory.findByLink(link);
-        if (!page) return link;
+        const {page, found} = pageDirectory.findByLink(link);
+        if (!found) return link;
 
         if (!page.data.backlinks) {
           page.data.backlinks = [];

--- a/src/wikilink-parser.js
+++ b/src/wikilink-parser.js
@@ -79,9 +79,13 @@ module.exports = class WikilinkParser {
     }
 
     // Lookup page data from 11ty's collection to obtain url and title if currently null
-    const page = pageDirectory.findByLink(meta);
+    const {page, foundByAlias} = pageDirectory.findByLink(meta);
     if (page) {
-      if (meta.title === null && page.data.title) meta.title = page.data.title;
+      if (foundByAlias) {
+        meta.title = meta.name;
+      } else if (meta.title === null && page.data.title) {
+        meta.title = page.data.title;
+      }
       meta.href = page.url;
       meta.path = page.inputPath;
       meta.exists = true;

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -50,7 +50,7 @@ test("Sample small Website (alias text used for link)", async t => {
 
   t.is(
     normalize(findResultByUrl(results, '/aliased-link-to-lonelyjuly/').content),
-    `<div><p>This should link with the alias as text <a href="/lonelyjuly/">LonelyJuly</a>.</p></div><div></div>`
+    `<div><p>This should link with the alias as text <a href="/lonelyjuly/">Aliased WikiLink</a>.</p></div><div></div>`
   );
 });
 

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -15,7 +15,7 @@ test("Sample small Website (wikilinks and regular links)", async t => {
 
   let results = await elev.toJSON();
 
-  t.is(results.length, 4);
+  t.is(results.length, 5);
 
   t.is(
     normalize(findResultByUrl(results, '/about/').content),
@@ -38,6 +38,19 @@ test("Sample small Website (htmlenteties)", async t => {
   t.is(
     normalize(findResultByUrl(results, '/linking-to-lonelyjuly/').content),
     `<div><p><a href="/lonelyjuly/">&gt;&gt;LONELYJULY&lt;&lt;</a></p></div><div></div>`
+  );
+});
+
+test("Sample small Website (alias text used for link)", async t => {
+  let elev = new Eleventy(fixturePath('sample-small-website'), fixturePath('sample-small-website/_site'), {
+    configPath: fixturePath('sample-small-website/eleventy.config.js'),
+  });
+
+  let results = await elev.toJSON();
+
+  t.is(
+    normalize(findResultByUrl(results, '/aliased-link-to-lonelyjuly/').content),
+    `<div><p>This should link with the alias as text <a href="/lonelyjuly/">LonelyJuly</a>.</p></div><div></div>`
   );
 });
 

--- a/tests/find-page-service.test.js
+++ b/tests/find-page-service.test.js
@@ -30,29 +30,33 @@ const pageDirectory = pageLookup([
 ], slugify);
 
 test('pageLookup (find by href)', t => {
-  t.is(pageDirectory.findByLink({href: '/something/else', isEmbed: false}).fileSlug, 'something-else');
+  const {page} = pageDirectory.findByLink({href: '/something/else', isEmbed: false});
+  t.is(page.fileSlug, 'something-else');
 });
 
 test('pageLookup (find by wikilink)', t => {
-  t.is(pageDirectory.findByLink({
+  const {page} = pageDirectory.findByLink({
     title: 'Hello World, Title',
     name: 'Hello World, Title',
     anchor: null,
     link: '[[Hello World, Title]]',
     slug: 'hello-world',
     isEmbed: false,
-  }).fileSlug, 'hello-world');
+  });
+
+  t.is(page.fileSlug, 'hello-world');
 });
 
 test('pageLookup (find by alias)', t => {
-  t.is(pageDirectory.findByLink({
+  const {page} = pageDirectory.findByLink({
     title: 'This is another page',
     name: 'test-alias',
     anchor: null,
     link: '[[test-alias]]',
     slug: 'test-alias',
     isEmbed: false,
-  }).fileSlug, 'something-else');
+  });
+  t.is(page.fileSlug, 'something-else');
 });
 
 // TODO: add testing when two pages share the same alias, what _should_ happen ?

--- a/tests/fixtures/sample-small-website/aliased-link-to-lonelyjuly.md
+++ b/tests/fixtures/sample-small-website/aliased-link-to-lonelyjuly.md
@@ -1,0 +1,6 @@
+---
+title: Aliased Link to LonelyJuly
+layout: default.liquid
+---
+
+This should link with the alias as text [[LonelyJuly]].

--- a/tests/fixtures/sample-small-website/aliased-link-to-lonelyjuly.md
+++ b/tests/fixtures/sample-small-website/aliased-link-to-lonelyjuly.md
@@ -3,4 +3,4 @@ title: Aliased Link to LonelyJuly
 layout: default.liquid
 ---
 
-This should link with the alias as text [[LonelyJuly]].
+This should link with the alias as text [[Aliased WikiLink]].

--- a/tests/fixtures/sample-small-website/lonelyjuly.md
+++ b/tests/fixtures/sample-small-website/lonelyjuly.md
@@ -2,6 +2,7 @@
 title: '>>LONELYJULY<<'
 aliases:
   - "LonelyJuly"
+  - "Aliased WikiLink"
 ---
 
 Lonely July Page


### PR DESCRIPTION
This PR fixes #41. Due to the 1.1.0 refactoring a regression was introduced where links would only ever render with the title of the page they link to being the link text. This PR fixes that by using the alias text for the link if it's the lookup source.