### PR TITLE
FEATURE: Add support for referencing file by path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for referencing files by path (#44)
 - Bugfix use alias as link text if it's the lookup source (#42)
 - Bugfix HTML encode link titles (#40)
 - Bugfix broken dead-links lookup due to typo (#38)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ For example, `[[Three laws of motion#Second law]]`.
 
 In cases where you have the `#` in the title of a page you're linking to you can escape using `/` foe example, `[[Programming in /#C, an introduction]]`.
 
+### Linking to files by path
+
+You can link to pages by their project path, or a path relative to the linking page, for example: `[[/blog/post-1234.md]]` would link to the page found at `/blog/post-1234` relative to the project root path, While `[[../../something.md]]` would link to a page two directories up.
+
 ### Aliases
 
 Aliases provide you a way of referencing a file using different names, use the `aliases` property in your font matter to list one or more aliases that can be used to reference the file from a Wiki Link. For example, you might add _AI_ as an alias of a file titled _Artificial Intelligence_ which would then be linkable via `[[AI]]`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ type WikilinkMeta = {
   link: string
   slug: string
   isEmbed: boolean
+  isPath: boolean,
   exists: boolean
 
   // href and path are loaded from the linked page

--- a/src/find-page.js
+++ b/src/find-page.js
@@ -11,14 +11,21 @@ const pageLookup = (allPages = [], slugifyFn) => {
     findByLink: (link) => {
       let foundByAlias = false;
       const page = allPages.find((page) => {
+
+        // Order of lookup:
+        // 1. if is path link, return filePathStem match state
+        // 2. match file url to link href
+        // 3. match file slug to link slug
+        // 4. match file title to link identifier (name)
+        // 5. match fle based upon alias
+
+        if (link.isPath) {
+          return page.filePathStem === link.name;
+        }
+
         if (link.href && (page.url === link.href || page.url === `${link.href}/`)) {
           return true;
         }
-
-        // Order of lookup:
-        // 1. match file slug to link slug
-        // 2. match file title to link identifier (name)
-        // 3. match fle based upon alias
 
         if (page.fileSlug === link.slug || (page.data.title && page.data.title === link.name)) {
           return true;

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -143,10 +143,12 @@ module.exports = class Interlinker {
           page.data.backlinks = [];
         }
 
-        page.data.backlinks.push({
-          url: currentPage.url,
-          title: currentPage.data.title,
-        });
+        if (page.data.backlinks.findIndex((backlink => backlink.url === currentPage.url)) === -1) {
+          page.data.backlinks.push({
+            url: currentPage.url,
+            title: currentPage.data.title,
+          });
+        }
 
         // If this is an embed and the embed template hasn't been compiled, add this to the queue
         // @TODO compiledEmbeds should be keyed by the wikilink text as i'll be allowing setting embed values via namespace, or other method e.g ![[ident||template]]

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -15,9 +15,6 @@ module.exports = class Interlinker {
     // Set of WikiLinks pointing to non-existent pages
     this.deadLinks = new DeadLinks();
 
-    // Map of what WikiLinks to what
-    this.linkMapCache = new Map();
-
     // Map of WikiLinks that have triggered an embed compile
     this.compiledEmbeds = new Map();
 
@@ -95,36 +92,10 @@ module.exports = class Interlinker {
       slugifyFn
     );
 
-    // TODO: 1.1.0 remove currentSlug as part of (#13)
-
-    const currentSlug = slugifyFn(data.title);
-    let currentSlugs = new Set([currentSlug, data.page.fileSlug]);
     const currentPage = pageDirectory.findByFile(data);
     if (!currentPage) return [];
 
-    // Populate our link map for use later in replacing WikiLinks with page permalinks.
-    // Pages can list aliases in their front matter, if those exist we should map them
-    // as well.
-
-    // TODO: 1.1.0 key files by title (#5)
-    this.linkMapCache.set(currentSlug, {
-      page: data.collections.all.find(page => page.url === data.page.url),
-      title: data.title
-    });
-
-    // If a page has defined aliases, then add those to the link map. These must be unique.
     // TODO: 1.1.0 keep track of defined aliases and throw exception if duplicates are found
-
-    if (data.aliases && Array.isArray(data.aliases)) {
-      for (const alias of data.aliases) {
-        const aliasSlug = slugifyFn(alias);
-        this.linkMapCache.set(aliasSlug, {
-          page: currentPage,
-          title: alias
-        });
-        currentSlugs.add(aliasSlug)
-      }
-    }
 
     // Identify this pages outbound internal links both as wikilink _and_ regular html anchor tags. For each outlink
     // lookup the other page and add this to its backlinks data value.

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -106,7 +106,6 @@ module.exports = class Interlinker {
     // Pages can list aliases in their front matter, if those exist we should map them
     // as well.
 
-    // TODO: 1.1.0 key files by pathname (#13)
     // TODO: 1.1.0 key files by title (#5)
     this.linkMapCache.set(currentSlug, {
       page: data.collections.all.find(page => page.url === data.page.url),
@@ -132,7 +131,7 @@ module.exports = class Interlinker {
     if (currentPage.template.frontMatter?.content) {
       const pageContent = currentPage.template.frontMatter.content;
       const outboundLinks  = [
-        ...this.wikiLinkParser.find(pageContent, pageDirectory),
+        ...this.wikiLinkParser.find(pageContent, pageDirectory, currentPage.filePathStem),
         ...this.HTMLLinkParser.find(pageContent, pageDirectory),
       ].map((link) => {
         // Lookup the page this link, links to and add this page to its backlinks

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -35,17 +35,23 @@ test("Sample small Website (path links)", async t => {
 
   let results = await elev.toJSON();
 
-  const n = 1;
+  // page-b is linked to from page-a
+  // path-link-outer is linked to from page-a
 
-  // t.is(
-  //   normalize(findResultByUrl(results, '/about/').content),
-  //   `<div><p>This is to show that we can link between Markdown files and <a href="/hello/">liquid files</a>.</p></div><div><a href="/hello/">Hello</a></div>`
-  // );
-  //
-  // t.is(
-  //   normalize(findResultByUrl(results, '/hello/').content),
-  //   '<div>This is to show that we can link back via <a href="/about">regular <em>internal</em> links</a>.</div><div><a href="/about/">About</a></div>',
-  // );
+  t.is(
+    normalize(findResultByUrl(results, '/path-links/page-a/').content),
+    `<div><p>We can Wikilink reference <a href="/path-links/hello/world/page-b/">by full project path</a>, and <a href="/path-links/hello/world/page-b/">by relative path</a> from current file path <a href="/path-link-outer/">Relative page up directory</a>.</p></div><div></div>`
+  );
+
+  t.is(
+    normalize(findResultByUrl(results, '/path-links/hello/world/page-b/').content),
+    `<div><p>This is Page B.</p></div><div><a href="/path-links/page-a/">Path Link Page A</a></div>`
+  );
+
+  t.is(
+    normalize(findResultByUrl(results, '/path-link-outer/').content),
+    `<div><p>Path Link test page</p></div><div><a href="/path-links/page-a/">Path Link Page A</a></div>`,
+  );
 });
 
 test("Sample small Website (htmlenteties)", async t => {

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -15,7 +15,7 @@ test("Sample small Website (wikilinks and regular links)", async t => {
 
   let results = await elev.toJSON();
 
-  t.is(results.length, 5);
+  t.is(results.length, 8);
 
   t.is(
     normalize(findResultByUrl(results, '/about/').content),
@@ -26,6 +26,26 @@ test("Sample small Website (wikilinks and regular links)", async t => {
     normalize(findResultByUrl(results, '/hello/').content),
     '<div>This is to show that we can link back via <a href="/about">regular <em>internal</em> links</a>.</div><div><a href="/about/">About</a></div>',
   );
+});
+
+test("Sample small Website (path links)", async t => {
+  let elev = new Eleventy(fixturePath('sample-small-website'), fixturePath('sample-small-website/_site'), {
+    configPath: fixturePath('sample-small-website/eleventy.config.js'),
+  });
+
+  let results = await elev.toJSON();
+
+  const n = 1;
+
+  // t.is(
+  //   normalize(findResultByUrl(results, '/about/').content),
+  //   `<div><p>This is to show that we can link between Markdown files and <a href="/hello/">liquid files</a>.</p></div><div><a href="/hello/">Hello</a></div>`
+  // );
+  //
+  // t.is(
+  //   normalize(findResultByUrl(results, '/hello/').content),
+  //   '<div>This is to show that we can link back via <a href="/about">regular <em>internal</em> links</a>.</div><div><a href="/about/">About</a></div>',
+  // );
 });
 
 test("Sample small Website (htmlenteties)", async t => {

--- a/tests/fixtures/sample-small-website/path-link-outer.md
+++ b/tests/fixtures/sample-small-website/path-link-outer.md
@@ -1,0 +1,5 @@
+---
+title: 'Relative page up directory'
+---
+
+Path Link test page

--- a/tests/fixtures/sample-small-website/path-link-outer.md
+++ b/tests/fixtures/sample-small-website/path-link-outer.md
@@ -1,5 +1,6 @@
 ---
 title: 'Relative page up directory'
+layout: default.liquid
 ---
 
 Path Link test page

--- a/tests/fixtures/sample-small-website/path-links/hello/world/page-b.md
+++ b/tests/fixtures/sample-small-website/path-links/hello/world/page-b.md
@@ -1,0 +1,6 @@
+---
+title: Path Link Page B
+layout: default.liquid
+---
+
+This is Page B.

--- a/tests/fixtures/sample-small-website/path-links/page-a.md
+++ b/tests/fixtures/sample-small-website/path-links/page-a.md
@@ -1,0 +1,6 @@
+---
+title: Path Link Page A
+layout: default.liquid
+---
+
+We can Wikilink reference [[/path-links/hello/world/page-b.md|by full project path]], and [[./hello/world/page-b.md|by relative path]] from current file path [[../path-link-outer.md]].

--- a/tests/wikilink-parser.test.js
+++ b/tests/wikilink-parser.test.js
@@ -5,9 +5,19 @@ const slugify = require("slugify");
 
 const pageDirectory = pageLookup([
   {
+    inputPath: '/home/user/website/hello-world.md',
+    filePathStem: '/hello-world',
     fileSlug: 'hello-world',
     data: {
       title: 'Hello World, Title',
+    },
+  },
+  {
+    inputPath: '/home/user/website/blog/a-blog-post.md',
+    filePathStem: '/blog/a-blog-post',
+    fileSlug: 'a-blog-post',
+    data: {
+      title: 'Blog Post',
     },
   }
 ], slugify);
@@ -116,3 +126,34 @@ test('populates dead links set', t => {
   t.is(deadLinks.size, 1);
   t.is(invalid.href, '/stubs');
 })
+
+test('parses path lookup', t => {
+  const deadLinks = new Set();
+  const parser = new WikilinkParser({slugifyFn: slugify}, deadLinks);
+
+  const parsed = parser.parseSingle('[[/blog/a-blog-post.md]]', pageDirectory);
+  t.is(parsed.isPath, true);
+  t.is(parsed.exists, true);
+  t.is(parsed.title, 'Blog Post');
+})
+
+test('parses relative path lookup (single back step)', t => {
+  const deadLinks = new Set();
+  const parser = new WikilinkParser({slugifyFn: slugify}, deadLinks);
+
+  const parsed = parser.parseSingle('[[../a-blog-post.md]]', pageDirectory, '/blog/sub-dir/some-page');
+  t.is(parsed.isPath, true);
+  t.is(parsed.exists, true);
+  t.is(parsed.title, 'Blog Post');
+})
+
+test('parses relative path lookup (multiple back step)', t => {
+  const deadLinks = new Set();
+  const parser = new WikilinkParser({slugifyFn: slugify}, deadLinks);
+
+  const parsed = parser.parseSingle('[[../../a-blog-post.md]]', pageDirectory, '/blog/sub-dir/sub-dir/some-page');
+  t.is(parsed.isPath, true);
+  t.is(parsed.exists, true);
+  t.is(parsed.title, 'Blog Post');
+})
+


### PR DESCRIPTION
This PR implements a feature requested in #13. It adds the ability for wikilinks to reference a file by path. The path can either be relative to the linking page, or relative to the project root, for example:

- `[[/sub-folder/sub-folder/filename.md]]` will link to the file found at that path relative to the project root
- `[[../../folder-name/filename.md]]` and `[[./sub-folder/filename.md]]` will link to the file found at that path relative to the linking files path