### PR TITLE
REFACTOR: Remove internal dependency upon slugify

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,9 +49,6 @@ type EleventyPluginInterlinkOptions = {
   // slug that you are using. This defaults to a function that returns [UNABLE TO LOCATE EMBED].
   unableToLocateEmbedFn?: ErrorRenderFn,
 
-  // slugifyFn is used to slugify strings. If a function isn't set then the default 11ty slugify filter is used.
-  slugifyFn?: SlugifyFn
-
   // resolvingFns is a list of resolving functions. These are invoked by a wikilink containing a `:` character
   // prefixed by the fn name. The page in this case is the linking page.
   resolvingFns?: Map<string, (link: WikilinkMeta, currentPage: any, interlinker: Interlinker) => Promise<string>>,
@@ -59,10 +56,6 @@ type EleventyPluginInterlinkOptions = {
 
 interface ErrorRenderFn {
   (slug: string): string;
-}
-
-interface SlugifyFn {
-  (input: string): string;
 }
 
 // Data structure for internal links identified by HTMLLinkParser.
@@ -78,7 +71,6 @@ type WikilinkMeta = {
   name: string
   anchor: string | null
   link: string
-  slug: string
   isEmbed: boolean
   isPath: boolean
 
@@ -103,4 +95,4 @@ interface PageDirectoryService {
   findByFile(file: any): any;
 }
 
-export {EleventyPluginInterlinkOptions, SlugifyFn, WikilinkMeta, LinkMeta, PageDirectoryService};
+export {EleventyPluginInterlinkOptions, WikilinkMeta, LinkMeta, PageDirectoryService};

--- a/index.js
+++ b/index.js
@@ -17,12 +17,6 @@ module.exports = function (eleventyConfig, options = {}) {
     defaultLayoutLang: null,
     layoutKey: 'embedLayout',
     layoutTemplateLangKey: 'embedLayoutLanguage',
-    slugifyFn: (input) => {
-      const slugify = eleventyConfig.getFilter('slugify');
-      if (typeof slugify !== 'function') throw new Error('Unable to load slugify filter.');
-
-      return slugify(input);
-    },
     resolvingFns: new Map(),
   }, options);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@photogabble/eleventy-plugin-interlinker",
-  "version": "1.1.0-rc2",
+  "version": "1.1.0-rc3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@photogabble/eleventy-plugin-interlinker",
-      "version": "1.1.0-rc2",
+      "version": "1.1.0-rc3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.1",
@@ -17,8 +17,7 @@
         "@11ty/eleventy": "^2.0.0",
         "ava": "^5.2.0",
         "c8": "^7.12.0",
-        "sinon": "^17.0.1",
-        "slugify": "^1.6.6"
+        "sinon": "^17.0.1"
       },
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "@11ty/eleventy": "^2.0.0",
     "ava": "^5.2.0",
     "c8": "^7.12.0",
-    "sinon": "^17.0.1",
-    "slugify": "^1.6.6"
+    "sinon": "^17.0.1"
   },
   "directories": {
     "test": "tests"

--- a/src/find-page.js
+++ b/src/find-page.js
@@ -2,12 +2,10 @@
  * Page Lookup Service:
  * This wraps the 11ty all pages collection providing two methods for finding pages.
  *
- * @todo slugifyFn is no longer removed, remove
  * @param {Array<any>} allPages
- * @param {import('@photogabble/eleventy-plugin-interlinker').SlugifyFn} slugifyFn
  * @return {import('@photogabble/eleventy-plugin-interlinker').PageDirectoryService}
  */
-const pageLookup = (allPages = [], slugifyFn) => {
+const pageLookup = (allPages = []) => {
   return {
     findByLink: (link) => {
       let foundByAlias = false;

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -63,13 +63,8 @@ module.exports = class Interlinker {
 
     this.deadLinks.setFileSrc(data.page.inputPath);
 
-    const {slugifyFn} = this.opts;
-
     const compilePromises = [];
-    const pageDirectory = pageLookup(
-      data.collections.all,
-      slugifyFn
-    );
+    const pageDirectory = pageLookup(data.collections.all);
 
     const currentPage = pageDirectory.findByFile(data);
     if (!currentPage) return [];

--- a/src/wikilink-parser.js
+++ b/src/wikilink-parser.js
@@ -12,7 +12,6 @@ module.exports = class WikilinkParser {
    */
   constructor(opts, deadLinks) {
     this.opts = opts;
-    this.slugifyFn = opts.slugifyFn;
     this.deadLinks = deadLinks;
 
     // TODO: when 11ty is in serve mode, this cache should clear at the beginning of each build (#24)
@@ -107,19 +106,12 @@ module.exports = class WikilinkParser {
       throw new Error(`Unable to find resolving fn [${fnName}] for wikilink ${link} on page [${filePathStem}]`);
     }
 
-    // TODO: is slugifying the name needed any more? We support wikilink ident being a page title, path or alias.
-    //       there should be no reason why the ident can't be a slug and we can lookup based upon that as well
-    //       without needing to slug it here... slug originally was used as a kind of id for lookup. That has
-    //       mostly been refactored out.
-    const slug = this.slugifyFn(name);
-
     /** @var {import('@photogabble/eleventy-plugin-interlinker').WikilinkMeta} */
     const meta = {
       title: parts.length === 2 ? parts[1] : null,
       name,
       anchor,
       link,
-      slug,
       isEmbed,
       isPath,
       exists: false,

--- a/tests/markdown-wikilink-parser.test.js
+++ b/tests/markdown-wikilink-parser.test.js
@@ -1,11 +1,9 @@
 const WikilinkParser = require('../src/wikilink-parser');
 const {wikilinkInlineRule} = require('../src/markdown-ext');
 const {defaultResolvingFn} = require("../src/resolvers");
-const slugify = require('slugify');
 const test = require('ava');
 
 const opts = {
-  slugifyFn: (text) => slugify(text),
   resolvingFns: new Map([
     ['default', defaultResolvingFn]
   ]),

--- a/tests/markdown-wikilink-renderer.test.js
+++ b/tests/markdown-wikilink-renderer.test.js
@@ -1,13 +1,10 @@
 const {wikilinkInlineRule, wikilinkRenderRule} = require('../src/markdown-ext');
 const WikilinkParser = require('../src/wikilink-parser');
 const {normalize} = require('./helpers');
-const slugify = require('slugify');
 const test = require('ava');
 const fs = require('fs');
 
-const opts = {
-  slugifyFn: (text) => slugify(text),
-};
+const opts = {};
 
 test('inline rule correctly parses single wikilink', t => {
   const wikilinkParser = new WikilinkParser(opts, new Set);

--- a/tests/wikilink-parser.test.js
+++ b/tests/wikilink-parser.test.js
@@ -1,9 +1,7 @@
 const WikilinkParser = require('../src/wikilink-parser');
 const {defaultResolvingFn, defaultEmbedFn} = require("../src/resolvers");
 const {pageLookup} = require("../src/find-page");
-const slugify = require("slugify");
 const test = require('ava');
-
 
 const pageDirectory = pageLookup([
   {
@@ -22,10 +20,9 @@ const pageDirectory = pageLookup([
       title: 'Blog Post',
     },
   }
-], slugify);
+]);
 
 const opts = {
-  slugifyFn: (text) => slugify(text),
   resolvingFns: new Map([
     ['default', defaultResolvingFn],
     ['default-embed', defaultEmbedFn],
@@ -34,40 +31,40 @@ const opts = {
 
 test('parses wikilink', t => {
   const parser = new WikilinkParser(opts, new Set());
-  t.like(parser.parseSingle('[[hello world]]', pageDirectory), {
+  t.like(parser.parseSingle('[[hello-world]]', pageDirectory), {
     title: 'Hello World, Title',
     anchor: null,
-    name: 'hello world',
+    name: 'hello-world',
     isEmbed: false
   });
 });
 
 test('parses wikilink with title', t => {
   const parser = new WikilinkParser(opts, new Set());
-  t.like(parser.parseSingle('[[hello world|Howdy]]', pageDirectory), {
+  t.like(parser.parseSingle('[[hello-world|Howdy]]', pageDirectory), {
     title: 'Howdy',
     anchor: null,
-    name: 'hello world',
+    name: 'hello-world',
     isEmbed: false
   });
 });
 
 test('parses wikilink with anchor', t => {
   const parser = new WikilinkParser(opts, new Set());
-  t.like(parser.parseSingle('[[hello world#heading one]]', pageDirectory), {
+  t.like(parser.parseSingle('[[hello-world#heading one]]', pageDirectory), {
     title: 'Hello World, Title',
     anchor: 'heading one',
-    name: 'hello world',
+    name: 'hello-world',
     isEmbed: false
   });
 });
 
 test('parses wikilink embed', t => {
   const parser = new WikilinkParser(opts, new Set());
-  t.like(parser.parseSingle('![[hello world]]', pageDirectory), {
+  t.like(parser.parseSingle('![[hello-world]]', pageDirectory), {
     title: 'Hello World, Title',
     anchor: null,
-    name: 'hello world',
+    name: 'hello-world',
     isEmbed: true
   });
 });
@@ -77,42 +74,42 @@ test('parses wikilinks with weird formatting', t => {
 
   const checks = [
     {
-      str: '[[hello world]]',
+      str: '[[hello-world]]',
       result: {
         title: 'Hello World, Title',
-        name: 'hello world',
+        name: 'hello-world',
         isEmbed: false
       }
     },
     {
-      str: '[[hello world|custom title]]',
+      str: '[[hello-world|custom title]]',
       result: {
         title: 'custom title',
-        name: 'hello world',
+        name: 'hello-world',
         isEmbed: false
       }
     },
     {
-      str: '[[ hello world | custom title ]]',
+      str: '[[ hello-world | custom title ]]',
       result: {
         title: 'custom title',
-        name: 'hello world',
+        name: 'hello-world',
         isEmbed: false
       }
     },
     {
-      str: '[[ hello world   |  custom title ]]',
+      str: '[[ hello-world   |  custom title ]]',
       result: {
         title: 'custom title',
-        name: 'hello world',
+        name: 'hello-world',
         isEmbed: false
       }
     },
     {
-      str: '![[hello world]]',
+      str: '![[hello-world]]',
       result: {
         title: 'Hello World, Title',
-        name: 'hello world',
+        name: 'hello-world',
         isEmbed: true
       }
     },
@@ -129,7 +126,7 @@ test('populates dead links set', t => {
   const parser = new WikilinkParser(opts, deadLinks);
   t.is(deadLinks.size, 0);
 
-  parser.parseSingle('[[hello world]]', pageDirectory);
+  parser.parseSingle('[[hello-world]]', pageDirectory);
   t.is(deadLinks.size, 0);
 
   const invalid = parser.parseSingle('[[invalid]]', pageDirectory);
@@ -182,7 +179,6 @@ test('throws error on failure to find resolvingFn', t => {
 
 test('sets resolvingFnName on finding resolvingFn', t => {
   const parser = new WikilinkParser({
-    slugifyFn: slugify,
     resolvingFns: new Map([
       ['test', () => 'Hello World']
     ]),


### PR DESCRIPTION
Having already refactored the page lookup code, this PR tidies up the loose end of using slugify on the wikilink identifier to match to a page; this caused unsessessary invocation of slugify.