### PR TITLE
FEATURE: Make dead link report configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Make dead link report configurable (#49)
 - Remove internal dependency upon slugify (#48)
 - Add support for custom rendering functions (#47)
 - Add support for referencing files by path (#44)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ type EleventyPluginInterlinkOptions = {
   // isn't set then the default 11ty slugify filter is used.
   slugifyFn?: SlugifyFn,
 
+  // deadLinkReport is the desired output format of the dead link report, by default its set to 'console'
+  deadLinkReport?: 'console' | 'json' | 'none',
+
   // resolvingFns contains functions used for resolving a wikilinks output.
   // see the Custom Resolving Functions section below
   resolvingFns?: Map<string, (link: WikilinkMeta, currentPage: any, interlinker: Interlinker) => Promise<string>>
@@ -194,6 +197,12 @@ You can then display this information in any way you would like, I use the below
     </nav>
 {% endif %}
 ```
+
+### Dead link Report
+
+The default behaviour of this plugin is to report to the console every broken Wikilink and internal link. This behaviour is configurable via the `deadLinkReport` config option. This option accepts three values: `none`, `console` and `json` with `console` being the default.
+
+Setting the value to `none` will disable the dead link report while setting it to `json` will silence console output instead writing to `.dead-links.json` within the project root folder.
 
 ### Page lookup logic
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,9 @@ type EleventyPluginInterlinkOptions = {
   // slug that you are using. This defaults to a function that returns [UNABLE TO LOCATE EMBED].
   unableToLocateEmbedFn?: ErrorRenderFn,
 
+  // deadLinkReport is the desired output format of the dead link report, by default its set to 'console'
+  deadLinkReport?: 'console' | 'json' | 'none',
+
   // resolvingFns is a list of resolving functions. These are invoked by a wikilink containing a `:` character
   // prefixed by the fn name. The page in this case is the linking page.
   resolvingFns?: Map<string, (link: WikilinkMeta, currentPage: any, interlinker: Interlinker) => Promise<string>>,

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function (eleventyConfig, options = {}) {
     layoutKey: 'embedLayout',
     layoutTemplateLangKey: 'embedLayoutLanguage',
     resolvingFns: new Map(),
+    deadLinkReport: 'console',
   }, options);
 
   // TODO: deprecate usage of unableToLocateEmbedFn in preference of using resolving fn
@@ -48,7 +49,9 @@ module.exports = function (eleventyConfig, options = {}) {
   // anything.
   // TODO: 1.1.0 have this contain more details such as which file(s) are linking (#23)
   // TODO: 1.1.0 have this clear the interlinker cache so that next time 11ty builds its starting from fresh data! (#24)
-  eleventyConfig.on('eleventy.after', () => interlinker.deadLinks.report());
+  eleventyConfig.on('eleventy.after', () => {
+    if (opts.deadLinkReport !== 'none') interlinker.deadLinks.report(opts.deadLinkReport)
+  });
 
   // Teach Markdown-It how to display MediaWiki Links.
   eleventyConfig.amendLibrary('md', (md) => {

--- a/src/dead-links.js
+++ b/src/dead-links.js
@@ -1,6 +1,8 @@
+const path = require('node:path');
 const chalk = require("chalk");
-module.exports = class DeadLinks {
+const fs = require('node:fs');
 
+module.exports = class DeadLinks {
   constructor() {
     this.gravestones = new Map;
     this.fileSrc = 'unknown';
@@ -44,7 +46,14 @@ module.exports = class DeadLinks {
       return;
     }
 
-    const json = JSON.stringify(this.gravestones);
-    const n =1;
+    let obj = {};
+    for (const [link, files] of this.gravestones.entries()) {
+      obj[link] = files;
+    }
+
+    fs.writeFileSync(
+      path.join(process.env.ELEVENTY_ROOT, '.dead-links.json'),
+      JSON.stringify(obj)
+    );
   }
 }

--- a/src/dead-links.js
+++ b/src/dead-links.js
@@ -25,17 +25,26 @@ module.exports = class DeadLinks {
     this.gravestones.set(link, names);
   }
 
-  report() {
-    for (const [link, files] of this.gravestones.entries()) {
-      console.warn(
-        chalk.blue('[@photogabble/wikilinks]'),
-        chalk.yellow('WARNING'),
-        `${(link.includes('href') ? 'Link' : 'Wikilink')} (${link}) found pointing to to non-existent page in:`
-      );
+  /**
+   * @param {'console'|'json'} format
+   */
+  report(format) {
+    if (format === 'console') {
+      for (const [link, files] of this.gravestones.entries()) {
+        console.warn(
+          chalk.blue('[@photogabble/wikilinks]'),
+          chalk.yellow('WARNING'),
+          `${(link.includes('href') ? 'Link' : 'Wikilink')} (${link}) found pointing to to non-existent page in:`
+        );
 
-      for (const file of files) {
-        console.warn(`\t- ${file}`);
+        for (const file of files) {
+          console.warn(`\t- ${file}`);
+        }
       }
+      return;
     }
+
+    const json = JSON.stringify(this.gravestones);
+    const n =1;
   }
 }

--- a/tests/fixtures/sample-with-hash-in-title/eleventy.config.js
+++ b/tests/fixtures/sample-with-hash-in-title/eleventy.config.js
@@ -1,6 +1,9 @@
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(
     require('../../../index.js'),
+    {
+      deadLinkReport: 'none'
+    }
   );
 
   return {

--- a/tests/fixtures/website-with-custom-resolving-fn/eleventy.config.js
+++ b/tests/fixtures/website-with-custom-resolving-fn/eleventy.config.js
@@ -6,6 +6,7 @@ module.exports = function (eleventyConfig) {
         ['howdy', (link, page) => `Hello ${link.name}!`],
         ['issue', (link, page) => `<a href="${page.data.github}/issues/${link.name}">#${link.name}</a>`],
       ]),
+      deadLinkReport: 'json',
     }
   );
 


### PR DESCRIPTION
This PR solves #45 by adding the `deadLinkReport` config option, accepting `'none'|'console'|'json'`.