### PR TITLE
FEATURE: clear internal state before each 11ty build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Clear internal state before each 11ty build (#51)
 - Make dead link report configurable (#49)
 - Remove internal dependency upon slugify (#48)
 - Add support for custom rendering functions (#47)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 I use [Obsidian.md](https://obsidian.md/) to draft my posts before they are published on PhotoGabble. One feature of #Obsidian that I love is interlinking between notes and being able to see the connectivity graph of each note.
 
-In January 2023 I wrote about how I [added Wiki Links support to Eleventy.js](https://www.photogabble.co.uk/noteworthy/adding-wiki-links-to-11ty/) and in doing so this plugin was borne. It has since been updated to include support for Obsidians [embedding files](https://help.obsidian.md/Linking+notes+and+files/Embedding+files).
+In January 2023 I wrote about how I [added Wiki Links support to Eleventy.js](https://www.photogabble.co.uk/noteworthy/adding-wiki-links-to-11ty/) and in doing so this plugin was borne. It has since been updated to include support for Obsidian's [embedding files](https://help.obsidian.md/Linking+notes+and+files/Embedding+files).
 
 ## Install
 
@@ -244,7 +244,7 @@ type WikilinkMeta = {
 
 ## Known Caveats
 
-- This plugin doesn't implement all [Obsidians wikilink support](https://help.obsidian.md/Linking+notes+and+files/Internal+links) for example linking to a block in a note and linking to a heading in a note is not currently supported by this plugin
+- This plugin doesn't implement all [Obsidian's wikilink support](https://help.obsidian.md/Linking+notes+and+files/Internal+links) for example linking to a block in a note and linking to a heading in a note is not currently supported by this plugin
 - Only supports embedding one note inside another, no other Obsidian file embedding functionality is currently supported by this plugin
 
 ## Roadmap

--- a/index.js
+++ b/index.js
@@ -47,9 +47,14 @@ module.exports = function (eleventyConfig, options = {}) {
 
   // After 11ty has finished generating the site output a list of wikilinks that do not link to
   // anything.
-  // TODO: 1.1.0 have this clear the interlinker cache so that next time 11ty builds its starting from fresh data! (#24)
   eleventyConfig.on('eleventy.after', () => {
-    if (opts.deadLinkReport !== 'none') interlinker.deadLinks.report(opts.deadLinkReport)
+    if (opts.deadLinkReport !== 'none') interlinker.deadLinks.report(opts.deadLinkReport);
+  });
+
+  // Reset the internal state of the interlinker if running in watch mode, this stops
+  // the interlinker from working against out of date data.
+  eleventyConfig.on('eleventy.beforeWatch', () => {
+    interlinker.reset();
   });
 
   // Teach Markdown-It how to display MediaWiki Links.

--- a/src/dead-links.js
+++ b/src/dead-links.js
@@ -56,4 +56,12 @@ module.exports = class DeadLinks {
       JSON.stringify(obj)
     );
   }
+
+  /**
+   * Reset to initial state
+   */
+  clear() {
+    this.fileSrc = 'unknown';
+    this.gravestones.clear();
+  }
 }

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -15,8 +15,11 @@ module.exports = class Interlinker {
   constructor(opts) {
     this.opts = opts
 
-    // Set of WikiLinks pointing to non-existent pages
+    // Map of WikiLinks pointing to non-existent pages
     this.deadLinks = new DeadLinks();
+
+    // Map of Wikilink Meta that have been resolved by the WikilinkParser
+    this.linkCache = new Map();
 
     // TODO: document
     this.templateConfig = undefined;
@@ -25,8 +28,13 @@ module.exports = class Interlinker {
     // TODO: document
     this.rm = new EleventyRenderPlugin.RenderManager();
 
-    this.wikiLinkParser = new WikilinkParser(opts, this.deadLinks);
+    this.wikiLinkParser = new WikilinkParser(opts, this.deadLinks, this.linkCache);
     this.HTMLLinkParser = new HTMLLinkParser(this.deadLinks);
+  }
+
+  reset() {
+    this.deadLinks.clear();
+    this.linkCache.clear();
   }
 
   /**

--- a/src/wikilink-parser.js
+++ b/src/wikilink-parser.js
@@ -9,13 +9,12 @@ module.exports = class WikilinkParser {
   /**
    * @param { import('@photogabble/eleventy-plugin-interlinker').EleventyPluginInterlinkOptions } opts
    * @param { DeadLinks } deadLinks
+   * @param { Map } linkCache
    */
-  constructor(opts, deadLinks) {
+  constructor(opts, deadLinks, linkCache) {
     this.opts = opts;
     this.deadLinks = deadLinks;
-
-    // TODO: when 11ty is in serve mode, this cache should clear at the beginning of each build (#24)
-    this.linkCache = new Map();
+    this.linkCache = linkCache;
   }
 
   /**

--- a/tests/eleventy.test.js
+++ b/tests/eleventy.test.js
@@ -62,7 +62,7 @@ test("Sample small Website (path links)", async t => {
   );
 });
 
-test("Sample small Website (htmlenteties)", async t => {
+test("Sample small Website (html entities)", async t => {
   let elev = new Eleventy(fixturePath('sample-small-website'), fixturePath('sample-small-website/_site'), {
     configPath: fixturePath('sample-small-website/eleventy.config.js'),
   });

--- a/tests/html-internal-link-parser.test.js
+++ b/tests/html-internal-link-parser.test.js
@@ -7,7 +7,7 @@ const pageDirectory = pageLookup([]);
 
 test('html link parser grabs multiple href, ignoring external links', t => {
     const parser = new HTMLLinkParser(new DeadLinks());
-    const links = parser.find('<p>Hello world <a href="/home">this is a link home</a> and <a href="/somewhere">this is a link somewhere</a></p><p>The following link should be ignored <a href="http://www.example.com/">example.com</a>.</p>', pageDirectory);
+    const links = parser.find('<p>Hello world <a href="/home">this is a link home</a> and <a href="/somewhere">this is a link somewhere</a></p><p>The following link should be ignored <a href="https://www.example.com/">example.com</a>.</p>', pageDirectory);
 
     t.is(2, links.length);
 

--- a/tests/markdown-wikilink-parser.test.js
+++ b/tests/markdown-wikilink-parser.test.js
@@ -10,7 +10,7 @@ const opts = {
 };
 
 test('inline rule correctly parses single wikilink', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
   wikilinkParser.linkCache.set('[[wiki link]]', {
     title: 'Wiki link',
     href: '/test/',
@@ -31,7 +31,7 @@ test('inline rule correctly parses single wikilink', t => {
 });
 
 test('inline rule correctly parses multiple wikilink', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
   wikilinkParser.linkCache.set('[[wiki links]]', {
     title: 'Wiki link',
     slug: 'wiki-links',
@@ -61,7 +61,7 @@ test('inline rule correctly parses multiple wikilink', t => {
 });
 
 test('inline rule correctly parses single wikilink embed', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
   wikilinkParser.linkCache.set('![[wiki link embed]]', {
     title: 'wiki link embed',
     slug: 'wiki-link-embed',
@@ -83,7 +83,7 @@ test('inline rule correctly parses single wikilink embed', t => {
 });
 
 test('inline rule correctly parses multiple wikilink embeds', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
   wikilinkParser.linkCache.set('![[wiki link embeds]]', {
     title: 'wiki link embed',
     slug: 'wiki-link-embed',
@@ -111,7 +111,7 @@ test('inline rule correctly parses multiple wikilink embeds', t => {
 });
 
 test('inline rule correctly parses mixed wikilink and wikilink embeds', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
   wikilinkParser.linkCache.set('![[wiki link embeds]]', {
     title: 'wiki link embeds',
     slug: 'wiki-link-embeds',

--- a/tests/markdown-wikilink-renderer.test.js
+++ b/tests/markdown-wikilink-renderer.test.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const opts = {};
 
 test('inline rule correctly parses single wikilink', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
 
   wikilinkParser.linkCache.set('[[wiki link]]', {
     title: 'Wiki Link',
@@ -31,7 +31,7 @@ test('inline rule correctly parses single wikilink', t => {
 });
 
 test('inline rule correctly parses multiple wikilinks', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
 
   wikilinkParser.linkCache.set('[[wiki link]]', {
     title: 'Wiki Link',
@@ -63,7 +63,7 @@ test('inline rule correctly parses multiple wikilinks', t => {
 });
 
 test('inline rule correctly parses single embed', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
 
   wikilinkParser.linkCache.set('![[wiki-embed]]', {
     title: 'Wiki Embed',
@@ -87,7 +87,7 @@ test('inline rule correctly parses single embed', t => {
 });
 
 test('inline rule correctly parses mixed wikilink and embed in multiline input', t => {
-  const wikilinkParser = new WikilinkParser(opts, new Set);
+  const wikilinkParser = new WikilinkParser(opts, new Set(), new Map());
 
   wikilinkParser.linkCache.set('![[inline embed]]', {
     title: 'Inline Embed',

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -40,7 +40,7 @@ test('hooks into eleventy.config', t => {
   plugin(eleventyMock);
   t.true(eleventyMock.wasCalled());
 
-  t.is(eleventyMock.calls.get('on'), 3); // eleventy.config, eleventy.extensionmap, eleventy.after
+  t.is(eleventyMock.calls.get('on'), 4); // eleventy.config, eleventy.extensionmap, eleventy.after, eleventy.beforeWatch
   t.is(eleventyMock.calls.get('amendLibrary'), 1); // Adding Markdown-it ext
   t.is(eleventyMock.calls.get('addGlobalData'), 1); // Adding global eleventyComputed data
 });

--- a/tests/wikilink-parser.test.js
+++ b/tests/wikilink-parser.test.js
@@ -30,7 +30,7 @@ const opts = {
 };
 
 test('parses wikilink', t => {
-  const parser = new WikilinkParser(opts, new Set());
+  const parser = new WikilinkParser(opts, new Set(), new Map());
   t.like(parser.parseSingle('[[hello-world]]', pageDirectory), {
     title: 'Hello World, Title',
     anchor: null,
@@ -40,7 +40,7 @@ test('parses wikilink', t => {
 });
 
 test('parses wikilink with title', t => {
-  const parser = new WikilinkParser(opts, new Set());
+  const parser = new WikilinkParser(opts, new Set(), new Map());
   t.like(parser.parseSingle('[[hello-world|Howdy]]', pageDirectory), {
     title: 'Howdy',
     anchor: null,
@@ -50,7 +50,7 @@ test('parses wikilink with title', t => {
 });
 
 test('parses wikilink with anchor', t => {
-  const parser = new WikilinkParser(opts, new Set());
+  const parser = new WikilinkParser(opts, new Set(), new Map());
   t.like(parser.parseSingle('[[hello-world#heading one]]', pageDirectory), {
     title: 'Hello World, Title',
     anchor: 'heading one',
@@ -60,7 +60,7 @@ test('parses wikilink with anchor', t => {
 });
 
 test('parses wikilink embed', t => {
-  const parser = new WikilinkParser(opts, new Set());
+  const parser = new WikilinkParser(opts, new Set(), new Map());
   t.like(parser.parseSingle('![[hello-world]]', pageDirectory), {
     title: 'Hello World, Title',
     anchor: null,
@@ -70,7 +70,7 @@ test('parses wikilink embed', t => {
 });
 
 test('parses wikilinks with weird formatting', t => {
-  const parser = new WikilinkParser(opts, new Set());
+  const parser = new WikilinkParser(opts, new Set(), new Map());
 
   const checks = [
     {
@@ -123,7 +123,7 @@ test('parses wikilinks with weird formatting', t => {
 
 test('populates dead links set', t => {
   const deadLinks = new Set();
-  const parser = new WikilinkParser(opts, deadLinks);
+  const parser = new WikilinkParser(opts, deadLinks, new Map());
   t.is(deadLinks.size, 0);
 
   parser.parseSingle('[[hello-world]]', pageDirectory);
@@ -136,7 +136,7 @@ test('populates dead links set', t => {
 
 test('parses path lookup', t => {
   const deadLinks = new Set();
-  const parser = new WikilinkParser(opts, deadLinks);
+  const parser = new WikilinkParser(opts, deadLinks, new Map());
 
   const parsed = parser.parseSingle('[[/blog/a-blog-post.md]]', pageDirectory);
   t.is(parsed.isPath, true);
@@ -146,7 +146,7 @@ test('parses path lookup', t => {
 
 test('parses relative path lookup (single back step)', t => {
   const deadLinks = new Set();
-  const parser = new WikilinkParser(opts, deadLinks);
+  const parser = new WikilinkParser(opts, deadLinks, new Map());
 
   const parsed = parser.parseSingle('[[../a-blog-post.md]]', pageDirectory, '/blog/sub-dir/some-page');
   t.is(parsed.isPath, true);
@@ -156,7 +156,7 @@ test('parses relative path lookup (single back step)', t => {
 
 test('parses relative path lookup (multiple back step)', t => {
   const deadLinks = new Set();
-  const parser = new WikilinkParser(opts, deadLinks);
+  const parser = new WikilinkParser(opts, deadLinks, new Map());
 
   const parsed = parser.parseSingle('[[../../a-blog-post.md]]', pageDirectory, '/blog/sub-dir/sub-dir/some-page');
   t.is(parsed.isPath, true);
@@ -165,7 +165,7 @@ test('parses relative path lookup (multiple back step)', t => {
 })
 
 test('throws error on failure to find resolvingFn', t => {
-  const parser = new WikilinkParser(opts, new Set());
+  const parser = new WikilinkParser(opts, new Set(), new Map());
   let errorMsg;
 
   try {
@@ -182,7 +182,7 @@ test('sets resolvingFnName on finding resolvingFn', t => {
     resolvingFns: new Map([
       ['test', () => 'Hello World']
     ]),
-  }, new Set());
+  }, new Set(), new Map());
 
   const link = parser.parseSingle('[[test:1234]]', pageDirectory, '/directory/filename');
 


### PR DESCRIPTION
This PR implements functionality for #24 by clearning the internal state before each 11ty build when running in `--watch` mode. This _should_ stop the plugin causing a crash when 11ty rebuilds due to a file being moved, deleted or renamed.