### PR TITLE
BUGFIX: On resolving fn lookup failure, only throw error if page not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- On resolving fn lookup failure, only throw error if page not found (#52)
 - Clear internal state before each 11ty build (#51)
 - Make dead link report configurable (#49)
 - Remove internal dependency upon slugify (#48)

--- a/tests/fixtures/website-with-broken-resolving-fn/_layouts/default.liquid
+++ b/tests/fixtures/website-with-broken-resolving-fn/_layouts/default.liquid
@@ -1,0 +1,2 @@
+<div>{{ content }}</div>
+<div>{%- for link in backlinks %}<a href="{{ link.url }}">{{ link.title }}</a>{%- endfor %}</div>

--- a/tests/fixtures/website-with-broken-resolving-fn/eleventy.config.js
+++ b/tests/fixtures/website-with-broken-resolving-fn/eleventy.config.js
@@ -1,0 +1,12 @@
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(
+    require('../../../index.js')
+  );
+
+  return {
+    dir: {
+      includes: "_includes",
+      layouts: "_layouts",
+    }
+  }
+}

--- a/tests/fixtures/website-with-broken-resolving-fn/index.md
+++ b/tests/fixtures/website-with-broken-resolving-fn/index.md
@@ -1,0 +1,6 @@
+---
+title: Homepage
+layout: default.liquid
+---
+
+This will cause an exception [[PHP Space Mines: Introduction|Moon Miner]]

--- a/tests/fixtures/website-with-custom-resolving-fn/index.md
+++ b/tests/fixtures/website-with-custom-resolving-fn/index.md
@@ -8,3 +8,4 @@ These wikilinks use custom resolving functions:
 
 - [[howdy:RWC]]
 - [[issue:19]]
+- [[PHP Space Mines: Introduction|Moon Miner]]

--- a/tests/fixtures/website-with-custom-resolving-fn/php-space-mines-introduction.md
+++ b/tests/fixtures/website-with-custom-resolving-fn/php-space-mines-introduction.md
@@ -1,0 +1,6 @@
+---
+title: 'PHP Space Mines: Introduction'
+layout: default.liquid
+---
+
+Hello World


### PR DESCRIPTION
This solves #50 by looking up page if custom resolving fn lookup fails to check if the `:` within the ident is actually part of a page title.