### PR TITLE
BUGFIX: Wikilinks should not contain new lines

### DIFF
--- a/src/wikilink-parser.js
+++ b/src/wikilink-parser.js
@@ -4,7 +4,7 @@ module.exports = class WikilinkParser {
    *
    * @type {RegExp}
    */
-  wikiLinkRegExp = /(?<!!)(!?)\[\[([^|]+?)(\|([\s\S]+?))?]]/g;
+  wikiLinkRegExp = /(?<!!)(!?)\[\[([^|\n]+?)(\|([^\n]+?))?]]/g;
 
   /**
    * @param { import('@photogabble/eleventy-plugin-interlinker').EleventyPluginInterlinkOptions } opts

--- a/tests/fixtures/website-with-permalink/hello.md
+++ b/tests/fixtures/website-with-permalink/hello.md
@@ -1,0 +1,36 @@
+---
+title: "Adding Wiki Links to 11ty"
+tags: [Blogging, 11ty, "Wiki Links"]
+aliases: [wiki-links]
+growthStage: seedling
+---
+
+Hello World
+
+{% raw %}
+```js
+module.exports = function(md, linkMapCache) {
+  // Recognize Mediawiki links ([[text]])
+  md.linkify.add("[[", {
+    validate: /^\s?([^\[\]\|\n\r]+)(\|[^\[\]\|\n\r]+)?\s?\]\]/,
+    normalize: match => {
+      const parts = match.raw.slice(2, -2).split("|");
+      const slug = slugify(parts[0].replace(/.(md|markdown)\s?$/i, "").trim());
+      const found = linkMapCache.get(slug);
+
+      if (!found) throw new Error(`Unable to find page linked by wikilink slug [${slug}]`)
+
+      match.text = parts.length === 2
+        ? parts[1]
+        : found.title;
+
+      match.url = found.permalink.substring(0,1) === '/'
+        ? found.permalink
+        : `/${found.permalink}`;
+    }
+  })
+};
+```
+{% endraw %}
+
+[[ test ]]

--- a/tests/wikilink-parser.test.js
+++ b/tests/wikilink-parser.test.js
@@ -189,3 +189,11 @@ test('sets resolvingFnName on finding resolvingFn', t => {
   t.is(link.resolvingFnName, 'test');
   t.is(link.name, '1234');
 })
+
+test('regex does not match on whitespace', t => {
+  const deadLinks = new Set();
+  const parser = new WikilinkParser(opts, deadLinks, new Map());
+  t.is(parser.find("[[ broken \nwikilink ]]", pageDirectory, '/').length, 0);
+  t.is(parser.find("[[ broken |wikilink \n]]", pageDirectory, '/').length, 0);
+  t.is(parser.find("[[\n broken wikilink]]", pageDirectory, '/').length, 0);
+})


### PR DESCRIPTION
This PR fixes a bug raised in #54, Wikilinks should not contain new lines.