### PR TITLE
BUGFIX: Fix crashing bug when embeded file changed while in `--watch` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix crashing bug when embedded file changed while in `--watch` mode (#56)
 - Wikilinks should not contain new lines (#54)
 - On resolving fn lookup failure, only throw error if page not found (#52)
 - Clear internal state before each 11ty build (#51)

--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ module.exports = function (eleventyConfig, options = {}) {
 
   const interlinker = new Interlinker(opts);
 
-  // TODO: document
+  // This populates templateConfig with an instance of TemplateConfig once 11ty has initiated it, it's
+  // used by the template compiler function that's exported by the EleventyRenderPlugin and used
+  // by the defaultEmbedFn resolving function for compiling embed templates.
   eleventyConfig.on("eleventy.config", (cfg) => {
     interlinker.templateConfig = cfg;
   });

--- a/src/interlinker.js
+++ b/src/interlinker.js
@@ -1,6 +1,5 @@
 const HTMLLinkParser = require("./html-link-parser");
 const WikilinkParser = require("./wikilink-parser");
-const {EleventyRenderPlugin} = require("@11ty/eleventy");
 const DeadLinks = require("./dead-links");
 const {pageLookup} = require("./find-page");
 
@@ -21,12 +20,11 @@ module.exports = class Interlinker {
     // Map of Wikilink Meta that have been resolved by the WikilinkParser
     this.linkCache = new Map();
 
-    // TODO: document
+    // Instance of TemplateConfig loaded by the `eleventy.config` event
     this.templateConfig = undefined;
-    this.extensionMap = undefined;
 
-    // TODO: document
-    this.rm = new EleventyRenderPlugin.RenderManager();
+    // Instance of EleventyExtensionMap loaded by the `eleventy.extensionmap` event
+    this.extensionMap = undefined;
 
     this.wikiLinkParser = new WikilinkParser(opts, this.deadLinks, this.linkCache);
     this.HTMLLinkParser = new HTMLLinkParser(this.deadLinks);

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,3 +1,4 @@
+const {EleventyRenderPlugin} = require("@11ty/eleventy");
 const entities = require("entities");
 /**
  * Default Resolving function for converting Wikilinks into html links.
@@ -48,7 +49,9 @@ const defaultEmbedFn = async (link, currentPage, interlinker) => {
     ? frontMatter.content
     : `{% layout "${layout}" %} {% block content %} ${frontMatter.content} {% endblock %}`;
 
-  const fn = await interlinker.rm.compile(tpl, language, {
+  const compiler = EleventyRenderPlugin.String;
+
+  const fn = await compiler(tpl, language, {
     templateConfig: interlinker.templateConfig,
     extensionMap: interlinker.extensionMap
   });


### PR DESCRIPTION
This PR fixes a bug raised in #33 by swapping out usage of `EleventyRenderPlugin.RenderManager` for `EleventyRenderPlugin.String` which is the exported template render function.

`EleventyRenderPlugin.RenderManager` ignores the `templateConfig` value passed to it, instead choosing to use its own internal state. When 11ty runs in `--watch` mode that internal state becomes different to what 11ty provides via its `eleventy.config` event. This is likely because the interlinker plugin is using `RenderManager` in a way its not intended to be used.

Fortunatly the compile function that `RenderManager.compile` wraps is also exported, however oddly named as `String`. This PR replaces usage of the render manager with usage of that compile function and should fix the crashing bug reported in #33.