### PR TITLE
FEATURE: Accept either string or array as page alias 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ You can link to pages by their project path, or a path relative to the linking p
 
 Aliases provide you a way of referencing a file using different names, use the `aliases` property in your font matter to list one or more aliases that can be used to reference the file from a Wiki Link. For example, you might add _AI_ as an alias of a file titled _Artificial Intelligence_ which would then be linkable via `[[AI]]`.
 
+These can be defined as either an array as shown below or a single alias via `aliaes: AI`.
+
 ```yaml
 ---
 title: Artificial Intelligence

--- a/src/find-page.js
+++ b/src/find-page.js
@@ -30,7 +30,10 @@ export const pageLookup = (allPages = []) => {
           return true;
         }
 
-        const aliases = ((page.data.aliases && Array.isArray(page.data.aliases)) ? page.data.aliases : []).reduce(function (set, alias) {
+        const aliases = ((page.data.aliases && Array.isArray(page.data.aliases))
+            ? page.data.aliases
+            : (typeof page.data.aliases === 'string' ? [page.data.aliases] : [])
+        ).reduce(function (set, alias) {
           set.add(alias);
           return set;
         }, new Set());

--- a/tests/find-page-service.test.js
+++ b/tests/find-page-service.test.js
@@ -25,6 +25,14 @@ const pageDirectory = pageLookup([
       aliases: ['test-alias']
     },
     url: '/something/else/'
+  },
+  {
+    fileSlug: 'string-lookup-test',
+    data: {
+      title: 'This is another page',
+      aliases: 'test-alias-string'
+    },
+    url: '/something/else/'
   }
 ]);
 
@@ -56,6 +64,19 @@ test('pageLookup (find by alias)', t => {
     isEmbed: false,
   });
   t.is(page.fileSlug, 'something-else');
+});
+
+test('pageLookup (find by alias as string)', t => {
+  const {page} = pageDirectory.findByLink({
+    title: 'This is another page',
+    name: 'test-alias-string',
+    anchor: null,
+    link: '[[test-alias-string]]',
+    slug: 'test-alias-string',
+    isEmbed: false,
+  });
+  t.is(typeof page, 'object');
+  t.is(page.fileSlug, 'string-lookup-test');
 });
 
 // TODO: add testing when two pages share the same alias, what _should_ happen ?


### PR DESCRIPTION
This PR implements functionality for #62 by accepting either an array or a string input as a page alias.