### PR TITLE
Fix: undefined property error for default layouts

### DIFF
--- a/src/markdown-ext.js
+++ b/src/markdown-ext.js
@@ -66,7 +66,7 @@ export const wikilinkBlockRule = (wikilinkParser) => (state, startLine, endLine,
   let lineText = state.src.slice(pos, max);
   if (lineText.substring(0, 3) !== '![[') return false;
 
-  const wikiLink = wikilinkParser.linkCache.get(lineText);
+  const wikiLink = wikiLink.content ? wikiLink.content.trim() : undefined;
   if (!wikiLink) return false;
 
   if (!silent) {

--- a/src/markdown-ext.js
+++ b/src/markdown-ext.js
@@ -66,12 +66,12 @@ export const wikilinkBlockRule = (wikilinkParser) => (state, startLine, endLine,
   let lineText = state.src.slice(pos, max);
   if (lineText.substring(0, 3) !== '![[') return false;
 
-  const wikiLink = wikiLink.content ? wikiLink.content.trim() : undefined;
+  const wikiLink = wikilinkParser.linkCache.get(lineText);
   if (!wikiLink) return false;
 
   if (!silent) {
     const token = state.push('html_block', '', 0);
-    token.content = wikiLink.content.trim();
+    token.content = wikiLink.content ? wikiLink.content.trim() : undefined;
   }
 
   // Block level Wikilink embeds should be on a single line, increment the line counter and continue.


### PR DESCRIPTION
Fix a "Cannot read properties of undefined (reading 'trim')" error thrown when attempting to read Wikilink Embeds that are bookended by new lines when a link contains no content. `wikiLink.content` is defined as `string | undefined` so we should handle this.